### PR TITLE
The 2018 Update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 10sr
+Copyright (c) 2018 github.com/10sr + contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # editorconfig-micro
 
-[EditorConfig][] Plugin for the [`micro`][] editor
+[EditorConfig] Plugin for the [`micro`] editor
 
 
 ### Prerequisites
 
-* [Micro][micro] editor >= 1.3.2
-* An `editorconfig` core executable (e.g. [EditorConfig C Core][])
+* [`micro`] editor >= 1.3.2
+* An `editorconfig` core executable (e.g. [EditorConfig C Core])
 
 
 ### Installation
@@ -15,7 +15,7 @@ While in micro's command mode (default keybinding: <kbd>CtrlE</kbd>):
 
 `plugin install editorconfig`
 
-That's all! This plugin will be automatically enabled after you restart `micro`.
+That's all! This plugin will be automatically enabled after you restart [`micro`].
 
 
 ### Supported Properties
@@ -25,9 +25,9 @@ That's all! This plugin will be automatically enabled after you restart `micro`.
 * `indent_size`
 * `tab_width`
 * `charset`
-  * Currently, `micro` only supports the UTF-8 charset.
+  * Currently, [`micro`] only [supports][EditorConfig Options] the UTF-8 charset.
 * `end_of_line`
-  * Currently, `micro` supports only LF and CRLF.
+  * Currently, [`micro`] only [supports][EditorConfig Options] LF and CRLF.
 * `insert_final_newline`
 * `trim_trailing_whitespace`
 
@@ -42,6 +42,7 @@ That's all! This plugin will be automatically enabled after you restart `micro`.
 This software is licensed under MIT License.
 See [LICENSE](LICENSE) for details.
 
-[micro]: https://micro-editor.github.io
+[`micro`]: https://micro-editor.github.io
 [EditorConfig]: http://editorconfig.org
+[EditorConfig Options]: https://github.com/zyedidia/micro/blob/master/runtime/help/options.md
 [EditorConfig C Core]: https://github.com/editorconfig/editorconfig-core-c

--- a/README.md
+++ b/README.md
@@ -1,56 +1,46 @@
-editorconfig-micro
-==================
+# editorconfig-micro
 
-[EditorConfig][] Plugin for [micro][] editor
-
-
-Prerequisite
-------------
-
-* [Micro][micro] editor >= 1.1.3
-* An `editorconfig` core executable ([EditorConfig C Core][] for example)
+[EditorConfig][] Plugin for the [`micro`][] editor
 
 
-Install
--------
+### Prerequisites
 
-Once you installed a core program, this plugin can be
-installed via micro plugin system:
-
-    > plugin install editorconfig
-
-(Type <kbd>CtrlE</kbd> `plugin install editorconfig` <kbd>Enter</kbd>)
-
-This plugin will be automatically enabled after you restart micro editor.
+* [Micro][micro] editor >= 1.3.2
+* An `editorconfig` core executable (e.g. [EditorConfig C Core][])
 
 
-Supported Properties
---------------------
+### Installation
 
+While in micro's command mode (default keybinding: <kbd>CtrlE</kbd>):
+
+`plugin install editorconfig`
+
+That's all! This plugin will be automatically enabled after you restart `micro`.
+
+
+### Supported Properties
+
+* `root` (only used by EditorConfig Core)
 * `indent_style`
 * `indent_size`
 * `tab_width`
-* `insert_final_newline`
-* `root` (Only used by EditorConfig Core)
-
-### On the Backlog
-
-* `end_of_line`
-  * Currently micro supports LF only
 * `charset`
-  * Currently micro supports UTF-8 only
+  * Currently, `micro` only supports the UTF-8 charset.
+* `end_of_line`
+  * Currently, `micro` supports only LF and CRLF.
+* `insert_final_newline`
 * `trim_trailing_whitespace`
+
+
+### Unsupported Properties
+
 * `max_line_length`
 
 
-
-License
--------
+### License
 
 This software is licensed under MIT License.
 See [LICENSE](LICENSE) for details.
-
-
 
 [micro]: https://micro-editor.github.io
 [EditorConfig]: http://editorconfig.org

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -40,7 +40,7 @@ local function setIndentation(properties, view)
         setSafely("tabstospaces", "off", view)
         setSafely("tabsize", tab_width, view)
     else
-        logger(("Unknown value for editorconfig directive indent_style: %s"):format(indent_style or "nil"), view)
+        logger(("Unknown value for editorconfig property indent_style: %s"):format(indent_style or "nil"), view)
         setSafely("tabsize", indent_size, view)
     end
 end
@@ -53,16 +53,16 @@ local function setEndOfLine(properties, view)
         setSafely("fileformat", "dos", view)
     elseif end_of_line == "cr" then
         -- See https://github.com/zyedidia/micro/blob/master/runtime/help/options.md for supported runtime options.
-        msg(("Value %s for editorconfig directive end_of_line is not currently supported by micro."):format(end_of_line), view)
+        msg(("Value %s for editorconfig property end_of_line is not currently supported by micro."):format(end_of_line), view)
     else
-        msg(("Unknown value for editorconfig directive end_of_line: %s"):format(end_of_line), view)
+        msg(("Unknown value for editorconfig property end_of_line: %s"):format(end_of_line), view)
     end
 end
 
 local function setCharset(properties, view)
     local charset = properties["charset"]
     if charset ~= "utf-8" then
-        msg(("Value %s for editorconfig directive charset is not currently supported by micro."):format(charset), view)
+        msg(("Value %s for editorconfig property charset is not currently supported by micro."):format(charset), view)
     end
 end
 
@@ -73,7 +73,7 @@ local function setTrimTrailingWhitespace(properties, view)
     elseif val == "false" then
         setSafely("rmtrailingws", false, view)
     else
-        logger(("Unknown value for editorconfig directive trim_trailing_whitespace: %s"):format(val), view)
+        logger(("Unknown value for editorconfig property trim_trailing_whitespace: %s"):format(val), view)
     end
 end
 
@@ -84,7 +84,7 @@ local function setInsertFinalNewline(properties, view)
     elseif val == "false" then
         setSafely("eofnewline", false, view)
     else
-        logger(("Unknown value for editorconfig directive insert_final_newline: %s"):format(val), view)
+        logger(("Unknown value for editorconfig property insert_final_newline: %s"):format(val), view)
     end
 end
 

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -1,4 +1,4 @@
-VERSION = "0.1.1"
+VERSION = "0.2.0"
 
 local function logger(msg, view)
     messenger:AddLog(("EditorConfig <%s>: %s"):

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -137,6 +137,7 @@ function onViewOpen(view)
 end
 
 function onSave(view)
+    getApplyProperties(view)
 end
 
 MakeCommand("editorconfig", "editorconfig.getApplyProperties")

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -50,7 +50,14 @@ local function setCodingSystem(properties, view)
     -- (Always use utf-8 with LF?)
     local end_of_line = properties["end_of_line"]
     local charset = properties["charset"]
-    if not (end_of_line == nil or end_of_line == "lf") then
+    if end_of_line == "lf" then
+        setSafely("fileformat", "unix", view)
+    elseif end_of_line == "crlf" then
+        setSafely("fileformat", "dos", view)
+    elseif end_of_line == "cr" then
+        -- See https://github.com/zyedidia/micro/blob/master/runtime/help/options.md for supported runtime options.
+        msg(("Value %s for editorconfig directive end_of_line is not currently supported by micro."):format(end_of_line), view)
+    else
         msg(("Unknown value for editorconfig directive end_of_line: %s"):format(end_of_line), view)
     end
     if not (charset == nil or charset == "utf-8") then

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -45,11 +45,8 @@ local function setIndentation(properties, view)
     end
 end
 
-local function setCodingSystem(properties, view)
-    -- Currently micro does not support changing coding-systems
-    -- (Always use utf-8 with LF?)
+local function setEndOfLine(properties, view)
     local end_of_line = properties["end_of_line"]
-    local charset = properties["charset"]
     if end_of_line == "lf" then
         setSafely("fileformat", "unix", view)
     elseif end_of_line == "crlf" then
@@ -60,10 +57,13 @@ local function setCodingSystem(properties, view)
     else
         msg(("Unknown value for editorconfig directive end_of_line: %s"):format(end_of_line), view)
     end
-    if not (charset == nil or charset == "utf-8") then
-        msg(("Unknown value for editorconfig directive charset: %s"):format(charset), view)
-    end
+end
 
+local function setCharset(properties, view)
+    local charset = properties["charset"]
+    if charset ~= "utf-8" then
+        msg(("Value %s for editorconfig directive charset is not currently supported by micro."):format(charset), view)
+    end
 end
 
 local function setTrimTrailingWhitespace(properties, view)
@@ -90,9 +90,8 @@ end
 
 local function applyProperties(properties, view)
     setIndentation(properties, view)
-    setCodingSystem(properties, view)
-    -- `ruler' is not what we want!
-    -- setMaxLineLength(properties, view)
+    setEndOfLine(properties, view)
+    setCharset(properties, view)
     setTrimTrailingWhitespace(properties, view)
     setInsertFinalNewline(properties, view)
 end

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -59,6 +59,17 @@ local function setCodingSystem(properties, view)
 
 end
 
+local function setTrimTrailingWhitespace(properties, view)
+    local val = properties["trim_trailing_whitespace"]
+    if val == "true" then
+        setSafely("rmtrailingws", true, view)
+    elseif val == "false" then
+        setSafely("rmtrailingws", false, view)
+    else
+        logger(("Unknown trim_trailing_whitespace: %s"):format(val), view)
+    end
+end
+
 local function setInsertFinalNewline(properties, view)
     local val = properties["insert_final_newline"]
     if val == "true" then
@@ -75,7 +86,7 @@ local function applyProperties(properties, view)
     setCodingSystem(properties, view)
     -- `ruler' is not what we want!
     -- setMaxLineLength(properties, view)
-    -- setTrimTrailingWhitespace(properties, view)
+    setTrimTrailingWhitespace(properties, view)
     setInsertFinalNewline(properties, view)
 end
 

--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -40,7 +40,7 @@ local function setIndentation(properties, view)
         setSafely("tabstospaces", "off", view)
         setSafely("tabsize", tab_width, view)
     else
-        logger(("Unknown indent_style: %s"):format(indent_style or "nil"), view)
+        logger(("Unknown value for editorconfig directive indent_style: %s"):format(indent_style or "nil"), view)
         setSafely("tabsize", indent_size, view)
     end
 end
@@ -51,10 +51,10 @@ local function setCodingSystem(properties, view)
     local end_of_line = properties["end_of_line"]
     local charset = properties["charset"]
     if not (end_of_line == nil or end_of_line == "lf") then
-        msg(("Unsupported end_of_line: %s"):format(end_of_line), view)
+        msg(("Unknown value for editorconfig directive end_of_line: %s"):format(end_of_line), view)
     end
     if not (charset == nil or charset == "utf-8") then
-        msg(("Unsupported charset: %s"):format(charset), view)
+        msg(("Unknown value for editorconfig directive charset: %s"):format(charset), view)
     end
 
 end
@@ -66,7 +66,7 @@ local function setTrimTrailingWhitespace(properties, view)
     elseif val == "false" then
         setSafely("rmtrailingws", false, view)
     else
-        logger(("Unknown trim_trailing_whitespace: %s"):format(val), view)
+        logger(("Unknown value for editorconfig directive trim_trailing_whitespace: %s"):format(val), view)
     end
 end
 
@@ -77,7 +77,7 @@ local function setInsertFinalNewline(properties, view)
     elseif val == "false" then
         setSafely("eofnewline", false, view)
     else
-        logger(("Unknown insert_final_newline: %s"):format(val), view)
+        logger(("Unknown value for editorconfig directive insert_final_newline: %s"):format(val), view)
     end
 end
 

--- a/help/editorconfig.md
+++ b/help/editorconfig.md
@@ -3,9 +3,9 @@ editorconfig-micro
 
 [EditorConfig][] helps developers define and maintain
 consistent coding styles between different editors and IDEs.
-This is the EditorConfig plugin for micro editor.
+This is the EditorConfig plugin for the `micro` editor.
 
-This plugin requires an editorconfig executable be installed.
+This plugin requires an editorconfig core executable to be installed.
 For example, download the [EditorConfig C Core][] and follow the instructions in
 the README and INSTALL files to install it.
 
@@ -14,21 +14,21 @@ Usage
 -----
 
 Once installed, this plugin will automatically execute `editorconfig` for
-current files and apply properties when opening buffers for them.
+current files and apply properties when opening buffers for them. `editorconfig`
+will also be executed upon every file save.
 
-This plugin also provides one command `editorconfig`.
+This plugin also provides one command: `editorconfig`.
 You can use this command to explicitly apply properties after updating
 `.editorconfig` files.
 
-By default there is no keybindings for this command, but you can bind a key to
-this command in you `bindings.json`:
+By default there are no keybindings for this command, but you can bind a key to
+this command in your `bindings.json`. For example:
 
 ``` json
 {
     "Alt-e": "editorconfig.getApplyProperties"
 }
 ```
-
 
 [EditorConfig]: http://editorconfig.org
 [EditorConfig C Core]: https://github.com/editorconfig/editorconfig-core-c

--- a/repo.json
+++ b/repo.json
@@ -4,10 +4,10 @@
   "Tags": ["editorconfig", "utility", "format"],
   "Versions": [
     {
-      "Version": "0.1.1",
-      "Url": "https://github.com/10sr/editorconfig-micro/archive/v0.1.1.zip",
+      "Version": "0.2.0",
+      "Url": "https://github.com/10sr/editorconfig-micro/archive/v0.2.0.zip",
       "Require": {
-        "micro": ">=1.1.3"
+        "micro": ">=1.3.2"
       }
     }
   ]


### PR DESCRIPTION
The changes are fairly small as this extension isn't much code, so I decided to just put everything in one PR.

Implemented:
* `trim_trailing_whitespace`
* `end_of_line`
* `charset`
* better error/incompatability/unsupported error messages
* changes also now applied per save \*\*\*

Revised docs and metadata:
* micro ver. [1.3.2](https://github.com/zyedidia/micro/releases/tag/v1.3.2) added support for LF and CRLF line endings, so that has been noted as the minimal compatible version
* license brought up to current year
* various english fixes in README and LICENSE and help doc
* Bumped version to 0.2.0 in `repo.json`

\*\*\* This can be brought up for discussion. Applying editorconfig changes per save is my personal preference (nice for things like seeing trailing whitespace go away). I believe the Atom editor also applies editorconfig per save.