### PR TITLE
feat: pin repo.json to 0.2.3 for micro 1.x compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Prerequisites
 
-* [`micro`] editor >= 1.3.2
+* 1.3.2 <= [`micro`] editor < 2.0.0
 * An `editorconfig` core executable (e.g. [EditorConfig C Core])
 
 

--- a/channel.json
+++ b/channel.json
@@ -1,3 +1,3 @@
 [
-  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json"
+  "https://raw.githubusercontent.com/10sr/editorconfig-micro/848fc839cad565c61d96b99f38121dda0f485607/repo.json"
 ]


### PR DESCRIPTION
This pins the hash for 0.2.3 for `repo.json`. See https://github.com/10sr/editorconfig-micro/pull/10#issuecomment-574972295.